### PR TITLE
Perf more

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,6 @@ repository = "https://github.com/alsotang/is_chinese_rs"
 license = "MIT"
 
 [dependencies]
-packed_simd = { version = "0.3.4", package = "packed_simd_2" }
-
 [dev-dependencies]
 criterion = "0.3"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,43 +10,43 @@
 //! assert!(!is_chinese::is_chinese("ss"));
 //! ```
 //!
-const CHINESE_SINGLE_CHAR: [u32; 20] = [
-    0xff0c, //，
-    0x3002, //。
-    0x00b7, //·
-    0x00d7, //×
-    0x2014, //—
-    0x2026, //…
-    0x3001, //、
-    0x300a, //《
-    0x300b, //》
-    0x300e, //『
-    0x300f, //』
-    0x3010, //【
-    0x3011, //】
-    0xff01, //！
-    0xff08, //（
-    0xff09, //）
-    0xff1a, //：
-    0xff1b, //；
-    0xff1f, //？
-    0xff1f, //HACK: ？ this duplicate for fit simd lane
-];
-// [2018, 2019, 3300, 33ff, 3400, 4dbf, 4e00, 9fff, f900, faff, fe30, fe4f, 20000, 2a6df, 2a700, 2b73f, 2b740, 2b81f, 2b820, 2ceaf, 2f800, 2fa1f]
-pub const CHINESE_RANGE: [u32; 24] = [
+
+const CHINESE_RANGE: &[[u32; 2]] = &[
     // sequence is determine by occurrence probability
-    0x4e00, 0x9fff, // CJK Unified Ideographs
-    0x2018, 0x2019, //‘- ’
-    0x3400, 0x4dbf, // CJK Unified Ideographs Extension A
-    0x20000, 0x2a6df, // CJK Unified Ideographs Extension B
-    0x2a700, 0x2b73f, // CJK Unified Ideographs Extension C
-    0x2b740, 0x2b81f, // CJK Unified Ideographs Extension D
-    0x2b820, 0x2ceaf, // CJK Unified Ideographs Extension E
-    0xf900, 0xfaff, // CJK Compatibility Ideographs
-    0x3300, 0x33ff, // https://en.wikipedia.org/wiki/CJK_Compatibility
-    0xfe30, 0xfe4f, // https://en.wikipedia.org/wiki/CJK_Compatibility_Forms
-    0xf900, 0xfaff, // https://en.wikipedia.org/wiki/CJK_Compatibility_Ideographs
-    0x2f800, 0x2fa1f, // https://en.wikipedia.org/wiki/CJK_Compatibility_Ideographs_Supplement
+    [0x4e00, 0x9fff], // CJK Unified Ideographs
+    // Chinese punctuation
+    [0xff0c, 0xff0c],   //，
+    [0x3002, 0x3002],   //。
+    [0x00b7, 0x00b7],   //·
+    [0x00d7, 0x00d7],   //×
+    [0x2014, 0x2014],   //—
+    [0x2018, 0x2018],   //‘
+    [0x2019, 0x2019],   //’
+    [0x201c, 0x201c],   //“
+    [0x201d, 0x201d],   //”
+    [0x2026, 0x2026],   //…
+    [0x3001, 0x3001],   //、
+    [0x300a, 0x300a],   //《
+    [0x300b, 0x300b],   //》
+    [0x300e, 0x300e],   //『
+    [0x300f, 0x300f],   //』
+    [0x3010, 0x3010],   //【
+    [0x3011, 0x3011],   //】
+    [0xff01, 0xff01],   //！
+    [0xff08, 0xff08],   //（
+    [0xff09, 0xff09],   //）
+    [0xff1a, 0xff1a],   //：
+    [0xff1b, 0xff1b],   //；
+    [0xff1f, 0xff1f],   //？
+    [0x3400, 0x4dbf],   // CJK Unified Ideographs Extension A
+    [0x20000, 0x2a6df], // CJK Unified Ideographs Extension B
+    [0x2a700, 0x2b73f], // CJK Unified Ideographs Extension C
+    [0x2b740, 0x2b81f], // CJK Unified Ideographs Extension D
+    [0x2b820, 0x2ceaf], // CJK Unified Ideographs Extension E
+    [0x3300, 0x33ff],   // https://en.wikipedia.org/wiki/CJK_Compatibility
+    [0xfe30, 0xfe4f],   // https://en.wikipedia.org/wiki/CJK_Compatibility_Forms
+    [0xf900, 0xfaff],   // https://en.wikipedia.org/wiki/CJK_Compatibility_Ideographs
+    [0x2f800, 0x2fa1f], // https://en.wikipedia.org/wiki/CJK_Compatibility_Ideographs_Supplement
 ];
 
 ///
@@ -60,20 +60,10 @@ pub fn is_chinese(str: &str) -> bool {
         return false;
     }
 
-    use packed_simd::u32x4;
     let is_all_chinese = str.chars().all(|c| {
-        let char_vec = u32x4::splat(c as u32);
-        CHINESE_SINGLE_CHAR
-            .chunks(4)
-            .map(u32x4::from_slice_unaligned)
-            .any(|char_vec| char_vec.eq(char_vec).any())
-            || CHINESE_RANGE
-                .chunks(4)
-                .map(u32x4::from_slice_unaligned)
-                .any(|slice| {
-                    let mask = char_vec.ge(slice).bitmask();
-                    mask == 1 || mask == 7
-                })
+        CHINESE_RANGE
+            .iter()
+            .any(|&[start, end]| c as u32 >= start && c as u32 <= end)
     });
 
     is_all_chinese

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,16 +19,15 @@
 /// assert!(is_chinese::is_chinese("中国"));
 /// ```
 pub fn is_chinese(str: &str) -> bool {
-    let has_ascii = str.chars().any(|c| c.is_ascii());
-
-    if has_ascii {
-        return false;
-    }
+    // let has_ascii = str.chars().any(|c| c.is_ascii());
+    // if has_ascii {
+    //     return false;
+    // }
 
     let is_all_chinese = str.chars().all(|c| {
         match c as u32 {
             0x4e00..=0x9fff => return true,
-            0xff0c..=0xff0c => {
+            0xff0c => {
                 return true;
             }
             0x3002 => {


### PR DESCRIPTION
这一次在我mac 机器上bench ，上一个 pr 是在我的主机上测试的，所以 参考基准不一样。
master branch: 

```bash
is_chinese("扁担宽，板凳长，扁担想绑在板凳上。")                                                                                             
                        time:   [83.674 ns 84.042 ns 84.506 ns]
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe

                                                                                                                                              is_chinese("ss扁担宽，板凳长，扁担想绑在板凳上。")                                         
                        time:   [2.0029 ns 2.0085 ns 2.0145 ns]
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

                                                                                                                                              is_chinese("扁担宽，板凳长，扁担想绑在板凳上。ss")                                         
                        time:   [43.542 ns 43.863 ns 44.326 ns]
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

isChinese(chars1000) true")                                                                             
                        time:   [4.6331 us 4.6485 us 4.6646 us]
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe

is_chinese("isChinese(chars1001) false")                                                                             
                        time:   [2.5277 us 2.5390 us 2.5559 us]
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe
```
perf branch: 
```bash
is_chinese("扁担宽，板凳长，扁担想绑在板凳上。")                                                                                              
                        time:   [38.533 ns 38.819 ns 39.152 ns]
                        change: [-54.813% -54.023% -53.260%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

                                                                                                                                              is_chinese("ss扁担宽，板凳长，扁担想绑在板凳上。")                                         
                        time:   [4.8136 ns 4.8368 ns 4.8620 ns]
                        change: [+138.40% +140.61% +142.54%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

                                                                                                                                              is_chinese("扁担宽，板凳长，扁担想绑在板凳上。ss")                                         
                        time:   [41.423 ns 41.788 ns 42.235 ns]
                        change: [-5.8544% -4.5882% -3.3184%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  3 (3.00%) high mild
  11 (11.00%) high severe

isChinese(chars1000) true")                                                                             
                        time:   [2.1482 us 2.1632 us 2.1816 us]
                        change: [-54.895% -54.039% -53.332%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  6 (6.00%) high mild
  7 (7.00%) high severe

is_chinese("isChinese(chars1001) false")                                                                             
                        time:   [2.1280 us 2.1559 us 2.1968 us]
                        change: [-17.167% -15.932% -14.731%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe
```
可以看到，除了 ascii 在字符串开头的情况，其均有大幅度提升，全是中文的情况下 提升大约两倍