### PR TITLE
feat: 🎸 simd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ repository = "https://github.com/alsotang/is_chinese_rs"
 license = "MIT"
 
 [dependencies]
+packed_simd = { version = "0.3.6", package = "packed_simd_2" }
+
 [dev-dependencies]
 criterion = "0.3"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,58 +13,70 @@
 //!
 //!
 //!
-
 ///
 /// ```
 /// assert!(is_chinese::is_chinese("中国"));
 /// ```
-pub fn is_chinese(str: &str) -> bool {
-    // let has_ascii = str.chars().any(|c| c.is_ascii());
-    // if has_ascii {
-    //     return false;
-    // }
+pub fn is_chinese(string: &str) -> bool {
+    let has_ascii = is_printable_ascii(string);
+    if has_ascii {
+        return false;
+    }
+    string.chars().all(is_chinese_char)
+}
 
-    let is_all_chinese = str.chars().all(|c| {
-        match c as u32 {
-            0x4e00..=0x9fff => return true,
-            0xff0c => {
-                return true;
-            }
-            0x3002 => {
-                return true;
-            }
-            0x3400..=0x4dbf => return true, // CJK Unified Ideographs Extension A
-            0x20000..=0x2a6df => return true, // CJK Unified Ideographs Extension B
-            0x2a700..=0x2b73f => return true, // CJK Unified Ideographs Extension C
-            0x2b740..=0x2b81f => return true, // CJK Unified Ideographs Extension D
-            0x2b820..=0x2ceaf => return true, // CJK Unified Ideographs Extension E
-            0x3300..=0x33ff => return true, // https://en.wikipedia.org/wiki/CJK_Compatibility
-            0xfe30..=0xfe4f => return true, // https://en.wikipedia.org/wiki/CJK_Compatibility_Forms
-            0xf900..=0xfaff => return true, // https://en.wikipedia.org/wiki/CJK_Compatibility_Ideographs
-            0x2f800..=0x2fa1f => return true, // https://en.wikipedia.org/wiki/CJK_Compatibility_Ideographs_Supplement
-            0x00b7 => return true,            //·
-            0x00d7 => return true,            //×
-            0x2014 => return true,            //—
-            0x2018 => return true,            //‘
-            0x2019 => return true,            //’
-            0x201c => return true,            //“
-            0x201d => return true,            //”
-            0x2026 => return true,            //…
-            0x3001 => return true,            //、
-            0x300a => return true,            //《
-            0x300b => return true,            //》
-            0x300e => return true,            //『
-            0x300f => return true,            //』
-            0x3010 => return true,            //【
-            0x3011 => return true,            //】
-            0xff01 => return true,            //！
-            0xff08 => return true,            //（
-            0xff09 => return true,            //）
-            0xff1a => return true,            //：
-            0xff1f => return true,            //？
-            _ => false,
+
+fn is_printable_ascii(string: &str) -> bool {
+    // println!("{}", string.len() % 16);
+    use packed_simd::u8x16;
+    let mask = u8x16::splat(127);
+    let bytes = string.as_bytes();
+    bytes.chunks_exact(16).map(u8x16::from_slice_unaligned).any(|v| {
+        let or = mask | v;
+        let res = or.eq(mask).any();
+        res
+    }) | &bytes[string.len() - string.len() % 16..].iter().any(|ch| *ch <= 127)
+}
+
+#[inline]
+fn is_chinese_char(ch: char) -> bool {
+    match ch as u32 {
+        0x4e00..=0x9fff => return true,
+        0xff0c => {
+            return true;
         }
-    });
-
-    is_all_chinese
+        0x3002 => {
+            return true;
+        }
+        0x3400..=0x4dbf => return true, // CJK Unified Ideographs Extension A
+        0x20000..=0x2a6df => return true, // CJK Unified Ideographs Extension B
+        0x2a700..=0x2b73f => return true, // CJK Unified Ideographs Extension C
+        0x2b740..=0x2b81f => return true, // CJK Unified Ideographs Extension D
+        0x2b820..=0x2ceaf => return true, // CJK Unified Ideographs Extension E
+        0x3300..=0x33ff => return true, // https://en.wikipedia.org/wiki/CJK_Compatibility
+        0xfe30..=0xfe4f => return true, // https://en.wikipedia.org/wiki/CJK_Compatibility_Forms
+        0xf900..=0xfaff => return true, // https://en.wikipedia.org/wiki/CJK_Compatibility_Ideographs
+        0x2f800..=0x2fa1f => return true, // https://en.wikipedia.org/wiki/CJK_Compatibility_Ideographs_Supplement
+        0x00b7 => return true,            //·
+        0x00d7 => return true,            //×
+        0x2014 => return true,            //—
+        0x2018 => return true,            //‘
+        0x2019 => return true,            //’
+        0x201c => return true,            //“
+        0x201d => return true,            //”
+        0x2026 => return true,            //…
+        0x3001 => return true,            //、
+        0x300a => return true,            //《
+        0x300b => return true,            //》
+        0x300e => return true,            //『
+        0x300f => return true,            //』
+        0x3010 => return true,            //【
+        0x3011 => return true,            //】
+        0xff01 => return true,            //！
+        0xff08 => return true,            //（
+        0xff09 => return true,            //）
+        0xff1a => return true,            //：
+        0xff1f => return true,            //？
+        _ => false,
+    }
 }


### PR DESCRIPTION
main branch: 

```bash
is_chinese("扁担宽，板凳长，扁担想绑在板凳上。")                                                                                              
                        time:   [38.533 ns 38.819 ns 39.152 ns]
                        change: [-54.813% -54.023% -53.260%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

is_chinese("ss扁担宽，板凳长，扁担想绑在板凳上。")                                         
                        time:   [4.8136 ns 4.8368 ns 4.8620 ns]
                        change: [+138.40% +140.61% +142.54%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

is_chinese("扁担宽，板凳长，扁担想绑在板凳上。ss")                                         
                        time:   [41.423 ns 41.788 ns 42.235 ns]
                        change: [-5.8544% -4.5882% -3.3184%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  3 (3.00%) high mild
  11 (11.00%) high severe

isChinese(chars1000) true")                                                                             
                        time:   [2.1482 us 2.1632 us 2.1816 us]
                        change: [-54.895% -54.039% -53.332%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  6 (6.00%) high mild
  7 (7.00%) high severe

is_chinese("isChinese(chars1001) false")                                                                             
                        time:   [2.1280 us 2.1559 us 2.1968 us]
                        change: [-17.167% -15.932% -14.731%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe
```
simd branch
```bash
is_chinese("扁担宽，板凳长，扁担想绑在板凳上。")                                         
                        time:   [52.302 ns 52.574 ns 52.884 ns]
Found 18 outliers among 100 measurements (18.00%)
  7 (7.00%) high mild
  11 (11.00%) high severe

is_chinese("ss扁担宽，板凳长，扁担想绑在板凳上。")                                         
                        time:   [4.1467 ns 4.1949 ns 4.2447 ns]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

is_chinese("扁担宽，板凳长，扁担想绑在板凳上。ss")                                         
                        time:   [4.8500 ns 4.8838 ns 4.9228 ns]
Found 10 outliers among 100 measurements (10.00%)
  8 (8.00%) high mild
  2 (2.00%) high severe

isChinese(chars1000) true")                                                                             
                        time:   [2.8905 us 2.9146 us 2.9424 us]
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe

is_chinese("isChinese(chars1001) false")                                                                            
                        time:   [100.18 ns 100.53 ns 100.94 ns]
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
```

这次修改使用simd 加速了扫描 可打印 ascii 的速度， 对于全是中文的情况有 30% 左右的回归，这是正常的。但是，对于有ascii 的情况下速度可以提升 10-20倍
这次实现没有像 之前的 ascii_check 一样使用 `chars()` 来做遍历，这是因为 chars()
由于 可打印 ascii 字符 均小于等于 `0x7f`, aka `01111111` 同时 utf-8 中的单字节字符最大也是 `0x7f`, 也就是说如果我们遍历 u8 时某一个 u8 小于等于127 他一定不属于任意中文字符中，参考
![image](https://user-images.githubusercontent.com/17974631/138057529-93f3f74f-dc5b-483e-b8bd-6a37753516d6.png)
```
The str type, also called a 'string slice', is the most primitive string type. It is usually seen in its borrowed form, &str. It is also the type of string literals, &'static str.

String slices are always valid UTF-8.
```
`&str ` 一定是 合法的 UTF-8 字符串。

因此一种很方便的方法就是遍历 &[u8] 判断是否有任意的 u8 <= 127, 如果有任意就说明存在一个可打印 ascii 字符，这里的逻辑
与你 nodejs 的实现是保持一致的。当然这里，很自然的想到用simd 来加速了。
